### PR TITLE
feat(jira): allow setting Jira version using env variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM addono/atlassian-sdk
 
+env JIRA_VERSION="8.9.0"
+
 COPY ./plugin .
 
 ENTRYPOINT ["atlas-run"]

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -178,7 +178,7 @@
     </build>
 
     <properties>
-        <jira.version>7.13.0</jira.version>
+        <jira.version>${env.JIRA_VERSION}</jira.version>
         <amps.version>8.0.2</amps.version>
         <plugin.testrunner.version>2.0.1</plugin.testrunner.version>
         <atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>


### PR DESCRIPTION
The desired Jira version can be set using the JIRA_VERSION environment variable.

BREAKING BREAKING BREAKING: now the Jira version also goes up to 8.9.0