### PR TITLE
feat: parameterise build for any Jira major (8 through 11)

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -1,0 +1,145 @@
+name: ghcr-publish
+
+# Publishes the current commit to GHCR for any Jira major. Every input
+# below maps 1:1 onto a Dockerfile ARG; defaults match the Dockerfile
+# defaults (Jira 8.20.30). Always builds AND publishes both the
+# unwarmed and the warmed variant in a single dispatch; the
+# `tag_latest` boolean controls only whether the floating
+# `:<major>[-warm]-latest` tags are pushed alongside the version-pinned
+# ones.
+#
+# Tag composition:
+#
+#   tag_latest=false (default):
+#     :<jira_version>          (unwarmed)
+#     :<jira_version>-warm     (warmed)
+#
+#   tag_latest=true:
+#     :<jira_version>          (unwarmed)
+#     :<jira_version>-warm     (warmed)
+#     :<jira_major>-latest     (unwarmed)
+#     :<jira_major>-warm-latest (warmed)
+#
+# Different majors do not collide on `:<major>[-warm]-latest`, so this
+# is safe to enable per release.
+
+on:
+  workflow_dispatch:
+    inputs:
+      jira_major:
+        description: "Jira major version (e.g. 11)"
+        required: true
+        type: string
+        default: "8"
+      jira_minor_patch:
+        description: "Jira minor.patch (e.g. 20.30)"
+        required: true
+        type: string
+        default: "20.30"
+      java_image:
+        description: "Java base image"
+        required: true
+        type: string
+        default: "eclipse-temurin:8-jdk-jammy"
+      amps_version:
+        description: "AMPS / jira-maven-plugin version (must resolve on both maven-external paths)"
+        required: true
+        type: string
+        default: "8.2.3"
+      spring_scanner_version:
+        description: "atlassian-spring-scanner version (2.1.x for Jira 8, 2.2.x for 9-10, 6.x for 11)"
+        required: true
+        type: string
+        default: "2.1.17"
+      testrunner_version:
+        description: "atlassian-plugins-osgi-testrunner version"
+        required: true
+        type: string
+        default: "2.0.16"
+      compile_floor:
+        description: "Java source/target compile floor (1.8 / 11 / 17)"
+        required: true
+        type: string
+        default: "1.8"
+      tag_latest:
+        description: "Also push :<major>[-warm]-latest floating tags"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/jira-software-standalone
+  JIRA_VERSION: ${{ inputs.jira_major }}.${{ inputs.jira_minor_patch }}
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    # Per-variant rough budget on a clean cache:
+    #   unwarmed build + push  ~10min
+    #   warmer-stage boot      ~15-25min
+    #   warmed export + push   ~5min
+    # Total ~50min; 90min ceiling absorbs slow GHCR / Maven days.
+    timeout-minutes: 90
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build unwarmed
+        run: |
+          docker build \
+            --target unwarmed \
+            --build-arg JAVA_IMAGE='${{ inputs.java_image }}' \
+            --build-arg AMPS_VERSION='${{ inputs.amps_version }}' \
+            --build-arg JIRA_VERSION='${{ env.JIRA_VERSION }}' \
+            --build-arg SPRING_SCANNER_VERSION='${{ inputs.spring_scanner_version }}' \
+            --build-arg TESTRUNNER_VERSION='${{ inputs.testrunner_version }}' \
+            --build-arg COMPILE_FLOOR='${{ inputs.compile_floor }}' \
+            -t '${{ env.IMAGE }}:${{ env.JIRA_VERSION }}' \
+            .
+
+      - name: Push unwarmed
+        run: docker push '${{ env.IMAGE }}:${{ env.JIRA_VERSION }}'
+
+      - name: Build warmed
+        # Re-uses the warmed stage's underlying base layers from the
+        # previous step's local cache; only the warmer-stage atlas-run
+        # boot is genuinely new work here.
+        run: |
+          docker build \
+            --target warmed \
+            --build-arg JAVA_IMAGE='${{ inputs.java_image }}' \
+            --build-arg AMPS_VERSION='${{ inputs.amps_version }}' \
+            --build-arg JIRA_VERSION='${{ env.JIRA_VERSION }}' \
+            --build-arg SPRING_SCANNER_VERSION='${{ inputs.spring_scanner_version }}' \
+            --build-arg TESTRUNNER_VERSION='${{ inputs.testrunner_version }}' \
+            --build-arg COMPILE_FLOOR='${{ inputs.compile_floor }}' \
+            -t '${{ env.IMAGE }}:${{ env.JIRA_VERSION }}-warm' \
+            .
+
+      - name: Push warmed
+        run: docker push '${{ env.IMAGE }}:${{ env.JIRA_VERSION }}-warm'
+
+      - name: Push :<major>-latest tags
+        if: inputs.tag_latest
+        run: |
+          UNWARMED_SRC='${{ env.IMAGE }}:${{ env.JIRA_VERSION }}'
+          WARMED_SRC='${{ env.IMAGE }}:${{ env.JIRA_VERSION }}-warm'
+          UNWARMED_DST='${{ env.IMAGE }}:${{ inputs.jira_major }}-latest'
+          WARMED_DST='${{ env.IMAGE }}:${{ inputs.jira_major }}-warm-latest'
+          docker tag "$UNWARMED_SRC" "$UNWARMED_DST"
+          docker tag "$WARMED_SRC" "$WARMED_DST"
+          docker push "$UNWARMED_DST"
+          docker push "$WARMED_DST"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,112 @@
-FROM addono/atlassian-sdk@sha256:12b2d4bd05d94cf5b1ea4c8f1c20ef08f5bf02b965a1105b011616626f08c10a
+# Single-source-of-truth Dockerfile for Jira Software dev images.
+# Every value that changes between Jira majors is exposed as an ARG so
+# the same Dockerfile boots Jira 8 (the historic default for this image)
+# all the way through Jira 11 (Jakarta / Spring 6) without forking.
+#
+# Defaults target the most recent Jira 8 LTS so a bare `docker build .`
+# preserves the legacy `addono/jira-software-standalone` behaviour.
+# The .github/workflows/ghcr-publish.yml workflow exposes every ARG as
+# a workflow_dispatch input.
 
-env JIRA_VERSION="8.9.0"
+# === ARGs =====================================================================
+# Java runtime image. Jira 11.x = JDK 21; 10.x = JDK 17; 9.x = JDK 11;
+# 8.x = JDK 8. https://confluence.atlassian.com/adminjiraserver/supported-platforms-938846830.html
+ARG JAVA_IMAGE=eclipse-temurin:8-jdk-jammy
 
-COPY ./plugin .
+# AMPS (Atlassian Maven Plugin Suite). Consumed in two places:
+#   - install-sdk.sh against the atlassian-plugin-sdk tarball
+#   - plugin/pom.xml.template against jira-maven-plugin
+# The two artifacts share a release train but can drift; verify both:
+#   https://packages.atlassian.com/maven-external/com/atlassian/amps/atlassian-plugin-sdk/maven-metadata.xml
+#   https://packages.atlassian.com/maven-external/com/atlassian/maven/plugins/jira-maven-plugin/maven-metadata.xml
+# Known-good combos: 8.2.3 (Jira 8), 9.1.2 (Jira 9 + 10), 9.11.2 (Jira 11).
+ARG AMPS_VERSION=8.2.3
 
-ENTRYPOINT ["atlas-run"]
+# Jira version baked as build-time default. Same image can boot any
+# patch within the major via `docker run -e JIRA_VERSION=...`.
+# The ENV that surfaces this to atlas-run lives inside the base stage
+# (ENV is not legal before the first FROM).
+ARG JIRA_VERSION=8.20.30
 
+# atlassian-spring-scanner. Jakarta-locked to Jira's Spring major:
+#   2.1.x = Jira 8 (Spring 5 / javax.*)
+#   2.2.x = Jira 9 + 10 (Spring 5 / javax.*)
+#   6.x   = Jira 11 (Spring 6 / Jakarta EE 10)
+# Crossing the streams (2.x against jakarta.*, 6.x against javax.*) silently no-ops.
+ARG SPRING_SCANNER_VERSION=2.1.17
+
+# atlassian-plugins-osgi-testrunner. Stable across Jira 8-11 on the 2.0.x line.
+ARG TESTRUNNER_VERSION=2.0.16
+
+# Java compile floor for the plugin jar. Match the runtime JDK so the
+# resulting class files load on the target Jira's classloader.
+ARG COMPILE_FLOOR=1.8
+
+# === base =====================================================================
+# Common scaffolding shared by `unwarmed`, `warmer`, and `warmed`.
+FROM ${JAVA_IMAGE} AS base
+
+# Re-declare ARGs after FROM so they're visible in this stage.
+ARG AMPS_VERSION
+ARG JIRA_VERSION
+ARG SPRING_SCANNER_VERSION
+ARG TESTRUNNER_VERSION
+ARG COMPILE_FLOOR
+
+ENV JIRA_VERSION=${JIRA_VERSION}
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV PATH=/opt/atlassian-plugin-sdk/bin:${PATH}
+
+# SDK install. Tarball is the only supported path - the apt repo at
+# packages.atlassian.com/atlassian-sdk-deb was retired Feb 2018.
+COPY scripts/install-sdk.sh /tmp/install-sdk.sh
+RUN bash /tmp/install-sdk.sh "${AMPS_VERSION}" && rm /tmp/install-sdk.sh
+
+WORKDIR /opt/jira-plugin
+COPY plugin/ ./
+COPY scripts/render-pom.sh /tmp/render-pom.sh
+RUN bash /tmp/render-pom.sh \
+        "${AMPS_VERSION}" \
+        "${SPRING_SCANNER_VERSION}" \
+        "${TESTRUNNER_VERSION}" \
+        "${COMPILE_FLOOR}" \
+        pom.xml.template \
+        pom.xml \
+    && rm /tmp/render-pom.sh pom.xml.template
+
+EXPOSE 2990
+
+# === warmer ===================================================================
+# Build-time-only stage. Runs atlas-run in the background, polls
+# /rest/api/2/serverInfo until 200, SIGTERMs the JVM, validates that
+# the warmed paths exist + are non-empty. The `warmed` stage COPY-s
+# those paths from this stage's filesystem.
+FROM base AS warmer
+COPY scripts/warm.sh /tmp/warm.sh
+RUN bash /tmp/warm.sh && rm /tmp/warm.sh
+
+# === warmed ===================================================================
+# Runtime stage with the Maven cache + unpacked Jira webapp baked in.
+# Caller picks this via `docker build --target warmed`. Cold-boot
+# becomes ~1-2min instead of ~10-20min because Maven downloads + war
+# unpack + initial DB schema are pre-populated. -o (offline) keeps
+# Maven from reaching out at runtime since the cache is fully populated.
+FROM base AS warmed
+COPY --from=warmer /root/.m2 /root/.m2
+COPY --from=warmer /opt/jira-plugin/target /opt/jira-plugin/target
+# -DskipAllPrompts=true: AMPS hardcodes a call to the shut-down
+# Atlassian Marketplace v1 endpoint at startup. This flag makes the
+# resulting 404 non-fatal so the boot proceeds.
+# Caller MUST run with -it; atlas-run exits without a TTY.
+ENTRYPOINT ["atlas-run", "-DskipAllPrompts=true", "-o"]
+
+# === unwarmed (default target) ================================================
+# Default `docker build .` target. Boots cold every container start
+# (~10-20min depending on Jira major). Use `--target warmed` to opt
+# into the pre-baked variant when the upfront ~25min build cost is
+# acceptable.
+FROM base AS unwarmed
+# -DskipAllPrompts=true: same Marketplace v1 endpoint workaround as
+# above. Caller MUST run with -it; atlas-run exits without a TTY.
+ENTRYPOINT ["atlas-run", "-DskipAllPrompts=true"]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,73 @@ docker run -d -it -p 2990:2990 --name jira addono/jira-software-standalone
 
 _Note: Make sure that the `-i` flag is enabled, as without it the server will exit the moment it completed booting._
 
+### Targeting a different Jira version
+
+The Dockerfile is parameterised; every value that changes between Jira majors
+is exposed as a `--build-arg`. `scripts/render-pom.sh` substitutes the matching
+`@TOKEN@` placeholders in `plugin/pom.xml.template` into a real `plugin/pom.xml`
+during the build, so the same source tree builds Jira 8 through Jira 11.
+
+```bash
+docker build \
+  --build-arg JAVA_IMAGE=eclipse-temurin:21-jdk-jammy \
+  --build-arg AMPS_VERSION=9.11.2 \
+  --build-arg JIRA_VERSION=11.3.4 \
+  --build-arg SPRING_SCANNER_VERSION=6.0.0 \
+  --build-arg COMPILE_FLOOR=17 \
+  -t jira-software-standalone:11.3.4 .
+```
+
+Defaults target the latest Jira 8 LTS (8.20.30 / Java 8 / AMPS 8.2.3) so a
+bare `docker build .` continues to produce the historical Jira 8 image.
+
+#### Known-good build-arg combinations
+
+Each row has been validated against a fresh `atlas-run` boot. Pass these
+as `--build-arg` flags when building locally, or as workflow inputs in
+`.github/workflows/ghcr-publish.yml`.
+
+| Jira version | `JAVA_IMAGE`                  | `AMPS_VERSION` | `SPRING_SCANNER_VERSION` | `TESTRUNNER_VERSION` | `COMPILE_FLOOR` |
+|--------------|-------------------------------|----------------|--------------------------|----------------------|-----------------|
+| 8.20.30      | `eclipse-temurin:8-jdk-jammy`  | `8.2.3`        | `2.1.17`                 | `2.0.16`             | `1.8`           |
+| 9.12.34      | `eclipse-temurin:11-jdk-jammy` | `9.1.2`        | `2.2.6`                  | `2.0.16`             | `11`            |
+| 10.3.19      | `eclipse-temurin:17-jdk-jammy` | `9.1.2`        | `2.2.6`                  | `2.0.16`             | `17`            |
+| 11.3.4       | `eclipse-temurin:21-jdk-jammy` | `9.11.2`       | `6.0.0`                  | `2.0.16`             | `17`            |
+
+Notes on the `AMPS_VERSION` line:
+
+- `AMPS_VERSION` feeds two artefacts that share a release train but
+  can drift: the SDK tarball (`atlassian-plugin-sdk`, consumed by
+  `scripts/install-sdk.sh`) and the build extension
+  (`com.atlassian.maven.plugins:jira-maven-plugin`, consumed by
+  `plugin/pom.xml.template`). Both must resolve at the chosen
+  version. Verify against
+  [the SDK metadata](https://packages.atlassian.com/maven-external/com/atlassian/amps/atlassian-plugin-sdk/maven-metadata.xml)
+  and
+  [the plugin metadata](https://packages.atlassian.com/maven-external/com/atlassian/maven/plugins/jira-maven-plugin/maven-metadata.xml).
+- For Jira 8 the SDK ships through `8.2.10` but the
+  `jira-maven-plugin` 8.2.x line tops out at `8.2.3`, so `8.2.3` is
+  the highest value that resolves on both paths.
+- For Jira 9 the older 8.2.x SDK ships an `atlas-run` that calls
+  `jira-maven-plugin:8.2.3` internally, which predates Jira 9 and
+  fails to launch a 9.x instance. The 9.1.x line is the lowest AMPS
+  that handles both Jira 9 and 10 cleanly (Spring 5 / `javax.*`
+  baseline carries through; Maven 3.9 in SDK 9.1.x runs on Java 11+).
+- `SPRING_SCANNER_VERSION` is Jakarta-locked to Jira's Spring major:
+  2.1.x for Jira 8, 2.2.x for Jira 9-10, 6.x for Jira 11. Crossing
+  the streams (2.x against `jakarta.*`, 6.x against `javax.*`)
+  silently no-ops at scan time.
+
+The Dockerfile is multi-stage: the default `unwarmed` target cold-boots on
+every container start (~10–20 min), and `--target warmed` bakes the result of
+one full `atlas-run` boot into the image so subsequent containers reach
+`/serverInfo` in ~1–2 min, at the cost of ~25 min of build time.
+
+`.github/workflows/ghcr-publish.yml` is a `workflow_dispatch` job that exposes
+every build-arg as an input and publishes both the unwarmed and warmed
+variants on every run; the optional `tag_latest` flag also pushes
+`:<major>-latest` and `:<major>-warm-latest` floating tags.
+
 ## Travis CI
 
 This is one way on how to use this image in a Travis CI pipeline. Add the following lines to your `.travis.yaml` file and access it at the location specified in the environment variables.

--- a/plugin/.gitignore
+++ b/plugin/.gitignore
@@ -1,1 +1,6 @@
 target/
+
+# Rendered from pom.xml.template by scripts/render-pom.sh during
+# `docker build`. Treat the template as source of truth; the rendered
+# pom is a build artefact.
+pom.xml

--- a/plugin/pom.xml.template
+++ b/plugin/pom.xml.template
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Source-of-truth pom rendered into plugin/pom.xml at docker build time
+  by scripts/render-pom.sh. Tokens of the form @ARG_NAME@ are filled
+  from the matching Dockerfile ARG; mirror any change here in the ARG
+  block at the top of Dockerfile.
 
+  The single Jira-version-aware property left as a Maven expression is
+  ${env.JIRA_VERSION} so the same image can boot any patch within the
+  built major via `docker run -e JIRA_VERSION=...`.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -179,16 +188,16 @@
 
     <properties>
         <jira.version>${env.JIRA_VERSION}</jira.version>
-        <amps.version>8.0.2</amps.version>
-        <plugin.testrunner.version>2.0.1</plugin.testrunner.version>
-        <atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>
+        <amps.version>@AMPS_VERSION@</amps.version>
+        <plugin.testrunner.version>@TESTRUNNER_VERSION@</plugin.testrunner.version>
+        <atlassian.spring.scanner.version>@SPRING_SCANNER_VERSION@</atlassian.spring.scanner.version>
         <!-- This property ensures consistency between the key in atlassian-plugin.xml and the OSGi bundle's key. -->
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
         <!-- TestKit version 6.x for JIRA 6.x -->
         <testkit.version>6.3.11</testkit.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>@COMPILE_FLOOR@</maven.compiler.source>
+        <maven.compiler.target>@COMPILE_FLOOR@</maven.compiler.target>
     </properties>
 
 </project>

--- a/scripts/install-sdk.sh
+++ b/scripts/install-sdk.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Install the Atlassian Plugin SDK from the maven-external tarball.
+# Apt path was retired Feb 2018, so curl-extract is the only supported
+# install pattern. Tarball URL pattern is stable across AMPS 9.x.
+#
+# Artifact coordinates: groupId=com.atlassian.amps,
+# artifactId=atlassian-plugin-sdk. Verify a chosen version is published
+# at:
+#   https://packages.atlassian.com/maven-external/com/atlassian/amps/atlassian-plugin-sdk/maven-metadata.xml
+#
+# Args:
+#   $1  AMPS version (e.g. 9.11.2)
+set -euo pipefail
+
+AMPS_VERSION="${1:?AMPS version required}"
+
+apt-get update
+apt-get install -y --no-install-recommends ca-certificates curl
+rm -rf /var/lib/apt/lists/*
+
+mkdir -p /opt/atlassian-plugin-sdk
+
+curl -fsSL \
+    "https://packages.atlassian.com/maven-external/com/atlassian/amps/atlassian-plugin-sdk/${AMPS_VERSION}/atlassian-plugin-sdk-${AMPS_VERSION}.tar.gz" \
+  | tar -xz -C /opt/atlassian-plugin-sdk --strip-components=1
+
+chmod -R a+rx /opt/atlassian-plugin-sdk/bin

--- a/scripts/render-pom.sh
+++ b/scripts/render-pom.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Substitute the @PLACEHOLDER@ tokens in plugin/pom.xml.template with
+# build-arg values and emit plugin/pom.xml. Invoked by the Dockerfile
+# during the base stage so a single source-of-truth template can serve
+# every Jira major - the surrounding Dockerfile ARG block names every
+# version pin that must change between majors.
+#
+# Args (positional, all required):
+#   $1  AMPS version            (com.atlassian.maven.plugins:jira-maven-plugin)
+#   $2  spring-scanner version  (atlassian-spring-scanner; must match
+#                                Jira's Spring/Jakarta major)
+#   $3  testrunner version      (atlassian-plugins-osgi-testrunner)
+#   $4  compile floor           (Java source/target; matches runtime JDK)
+#   $5  template path           (default: plugin/pom.xml.template)
+#   $6  output path             (default: plugin/pom.xml)
+#
+# Adding a new placeholder is two edits: a new `-e` to the sed call,
+# and a new ARG block in the Dockerfile that surfaces the value.
+# A new placeholder NOT wired into the sed call will trip the drift
+# guard below, since it survives untouched in the rendered pom.
+set -euo pipefail
+
+AMPS_VERSION="${1:?AMPS version required}"
+SPRING_SCANNER_VERSION="${2:?spring-scanner version required}"
+TESTRUNNER_VERSION="${3:?testrunner version required}"
+COMPILE_FLOOR="${4:?compile floor required}"
+TEMPLATE="${5:-plugin/pom.xml.template}"
+OUTPUT="${6:-plugin/pom.xml}"
+
+if [ ! -f "$TEMPLATE" ]; then
+    echo "render-pom: template not found at $TEMPLATE" >&2
+    exit 1
+fi
+
+sed \
+    -e "s|@AMPS_VERSION@|${AMPS_VERSION}|g" \
+    -e "s|@SPRING_SCANNER_VERSION@|${SPRING_SCANNER_VERSION}|g" \
+    -e "s|@TESTRUNNER_VERSION@|${TESTRUNNER_VERSION}|g" \
+    -e "s|@COMPILE_FLOOR@|${COMPILE_FLOOR}|g" \
+    "$TEMPLATE" > "$OUTPUT"
+
+# Drift guard: any `@TOKEN@` sitting inside an XML element (or as the
+# value of an attribute) survived sed and is therefore a placeholder
+# the substitution block above forgot. The XML-context anchors
+# (`>@...@<`, `="@...@"`) keep this from false-positive-ing on the
+# bare `@ARG_NAME@` prose example in the template's header comment.
+if grep -nE '(>@[A-Z_]+@<|="@[A-Z_]+@")' "$OUTPUT" >&2; then
+    echo "render-pom: unsubstituted placeholder(s) remain in $OUTPUT" >&2
+    exit 1
+fi

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Smoke-test a freshly-built jira-software-standalone image: start it,
+# poll until Jira responds (cold boot 10-20min), confirm /serverInfo
+# returns the expected version, dump container logs to artifacts/
+# regardless of outcome.
+#
+# Args:
+#   $1  Image tag (e.g. ghcr.io/adehad/jira-software-standalone:11.3.4)
+#   $2  Expected Jira version (asserted against /serverInfo JSON)
+#   $3  Artifacts directory
+set -euo pipefail
+
+IMAGE="${1:?image tag required}"
+EXPECTED_VERSION="${2:?expected version required}"
+ARTIFACTS_DIR="${3:?artifacts directory required}"
+NAME=jira-smoke
+READY_URL=http://localhost:2990/jira/secure/Dashboard.jspa
+INFO_URL=http://localhost:2990/jira/rest/api/2/serverInfo
+POLL_INTERVAL=10
+MAX_POLLS=180   # 30 min ceiling
+
+mkdir -p "$ARTIFACTS_DIR"
+
+cleanup() {
+    docker logs "$NAME" > "$ARTIFACTS_DIR/container.log" 2>&1 || true
+    docker rm -f "$NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# Pre-flight: drop any stale container left by a hard-killed previous
+# run (Ctrl+C, kill -9). The cleanup trap handles graceful exits, but
+# only on signals it can catch.
+docker rm -f "$NAME" 2>/dev/null || true
+
+# Tee docker run's stderr+stdout to smoke-run.log so pre-container
+# failures (image pull errors, port collisions, name conflicts) are
+# captured in artifacts even when no container exists for `docker logs`
+# to read from.
+docker run -dit -p 2990:2990 --name "$NAME" "$IMAGE" \
+    2>&1 | tee "$ARTIFACTS_DIR/smoke-run.log"
+
+ready=0
+# GET (not HEAD): Jira 11 returns 405 Method Not Allowed on HEAD for
+# secure servlets like Dashboard.jspa. GET produces a 200 once the
+# webapp is up. Output is discarded via -o /dev/null to avoid streaming
+# the rendered HTML.
+for ((i = 1; i <= MAX_POLLS; i++)); do
+    if curl --output /dev/null --silent --fail "$READY_URL"; then
+        echo "Jira responsive after $((i * POLL_INTERVAL))s"
+        ready=1
+        break
+    fi
+    sleep "$POLL_INTERVAL"
+done
+
+if [ "$ready" != "1" ]; then
+    echo "Jira not responsive after $((MAX_POLLS * POLL_INTERVAL))s" >&2
+    exit 1
+fi
+
+RESP=$(curl --silent --show-error --fail -u admin:admin "$INFO_URL")
+echo "$RESP" | tee "$ARTIFACTS_DIR/server-info.json"
+echo "$RESP" | grep -F "\"version\":\"$EXPECTED_VERSION\"" \
+    || { echo "Version mismatch: expected $EXPECTED_VERSION" >&2; exit 1; }

--- a/scripts/warm.sh
+++ b/scripts/warm.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Build-time warmer. Boots atlas-run in the background, polls
+# /rest/api/2/serverInfo until 200, SIGTERMs the JVM, waits for
+# graceful shutdown, and validates the warmed paths exist + are
+# non-empty.
+#
+# The `warmed` runtime stage COPY-s these paths from this stage:
+#   /root/.m2/repository    - Maven cache (Jira deps, plugins, etc.)
+#   /opt/jira-plugin/target - atlas-run unpacks Jira's webapp + the
+#                             local plugin jar + initial HSQLDB here
+#
+# Failure modes that abort the build (rather than baking a half-warm
+# image):
+#   - atlas-run exits before /serverInfo becomes responsive
+#   - poll ceiling hit (cold boot exceeded MAX_POLLS * POLL_INTERVAL)
+#   - either warmed path missing or empty after shutdown
+set -euo pipefail
+
+LOG=/tmp/warm.log
+WORKDIR_TARGET=/opt/jira-plugin/target
+M2_REPO=/root/.m2/repository
+READY_URL=http://localhost:2990/jira/rest/api/2/serverInfo
+POLL_INTERVAL=10
+MAX_POLLS=180  # 30 min ceiling; cold boot of Jira 11 is ~10-20min
+
+# atlas-run hardcodes a call to the shut-down Atlassian Marketplace v1
+# endpoint at startup; -DskipAllPrompts=true makes that 404 non-fatal.
+#
+# stdin is redirected from /dev/zero (not /dev/null) because the Cargo
+# Maven plugin behind `atlas-run` reads stdin after "Type Ctrl-C to
+# shutdown gracefully" and treats EOF as Ctrl-C. Docker build has no
+# TTY, so /dev/null (or inherited closed stdin) returns EOF immediately
+# and Jira shuts down within ~1s of finishing startup -- before the
+# poll loop below can confirm /serverInfo. /dev/zero blocks the read
+# forever, keeping the JVM alive until we send SIGTERM ourselves.
+atlas-run -DskipAllPrompts=true < /dev/zero > "$LOG" 2>&1 &
+ATLAS_PID=$!
+echo "[warm] atlas-run pid=$ATLAS_PID, polling $READY_URL ..."
+
+ready=0
+for ((i = 1; i <= MAX_POLLS; i++)); do
+    if curl --output /dev/null --silent --fail -u admin:admin "$READY_URL"; then
+        echo "[warm] /serverInfo responsive after $((i * POLL_INTERVAL))s"
+        ready=1
+        break
+    fi
+    if ! kill -0 "$ATLAS_PID" 2>/dev/null; then
+        echo "[warm] FAIL: atlas-run exited early (pid $ATLAS_PID gone)" >&2
+        echo "[warm] last 200 lines of warm.log:" >&2
+        tail -200 "$LOG" >&2
+        exit 1
+    fi
+    sleep "$POLL_INTERVAL"
+done
+
+if [ "$ready" != "1" ]; then
+    echo "[warm] FAIL: /serverInfo never became responsive after $((MAX_POLLS * POLL_INTERVAL))s" >&2
+    tail -200 "$LOG" >&2
+    kill -TERM "$ATLAS_PID" 2>/dev/null || true
+    exit 1
+fi
+
+# SIGTERM the JVM. atlas-run forwards to mvn which forwards to Jetty;
+# Jetty graceful shutdown takes ~30s. Wait for the process tree to
+# drain so the warmed paths are not mid-write.
+echo "[warm] shutting down atlas-run gracefully ..."
+kill -TERM "$ATLAS_PID"
+wait "$ATLAS_PID" 2>/dev/null || true
+
+# Validate the paths the warmed runtime stage will COPY. If atlas-run's
+# unpack location ever changes (e.g. AMPS major bump moves the webapp
+# from target/ to elsewhere), this loop fails fast so we do not bake
+# an image where the cache lives but the webapp does not.
+for path in "$M2_REPO" "$WORKDIR_TARGET"; do
+    if [ ! -d "$path" ]; then
+        echo "[warm] FAIL: expected warmed path $path does not exist" >&2
+        exit 1
+    fi
+    if [ -z "$(ls -A "$path" 2>/dev/null)" ]; then
+        echo "[warm] FAIL: expected warmed path $path is empty" >&2
+        exit 1
+    fi
+    size=$(du -sb "$path" 2>/dev/null | awk '{print $1}')
+    echo "[warm] OK: $path size=${size} bytes"
+done
+
+echo "[warm] done"


### PR DESCRIPTION
Replaces the single hard-coded `addono/atlassian-sdk` base image with a multi-stage Dockerfile whose every Jira-major-specific knob is a build-arg, so the same source tree builds Jira 8, 9, 10, or 11 by flipping ARGs alone. `plugin/pom.xml` becomes `plugin/pom.xml.template` with `@TOKEN@` placeholders that `scripts/render-pom.sh` substitutes during the `base` stage.

Defaults preserve the historic behaviour of this image: a bare `docker build .` produces Jira 8 (now 8.20.30, the final 8.x LTS) on JDK 8, so existing consumers of `addono/jira-software-standalone:latest` keep working.

What changed:

  Dockerfile
    Six ARGs (JAVA_IMAGE, AMPS_VERSION, JIRA_VERSION,
    SPRING_SCANNER_VERSION, TESTRUNNER_VERSION, COMPILE_FLOOR) drive
    the version pins. Three stages (base / warmer / warmed / unwarmed)
    let callers opt into a pre-warmed image (~1-2 min cold-boot in
    exchange for ~25 min build time) via `--target warmed`.
    Defaults: Jira 8.20.30 / Java 8 / AMPS 8.2.3 / scanner 2.1.17 /
    compile floor 1.8.

  plugin/pom.xml -> plugin/pom.xml.template
    Same content; `@AMPS_VERSION@`, `@SPRING_SCANNER_VERSION@`,
    `@TESTRUNNER_VERSION@`, and `@COMPILE_FLOOR@` placeholders take the
    place of the hard-coded property values. Rendered to plugin/pom.xml
    during build by scripts/render-pom.sh and excluded from git.

  scripts/install-sdk.sh
    Installs atlassian-plugin-sdk from the maven-external tarball
    (the apt repo at packages.atlassian.com/atlassian-sdk-deb was
    retired Feb 2018).

  scripts/render-pom.sh
    Substitutes the four `@TOKEN@` values into the template; fails
    loudly if any placeholder is left untouched.

  scripts/warm.sh
    Builds the `warmer` stage. Boots atlas-run in the background,
    polls /rest/api/2/serverInfo until 200, SIGTERMs the JVM, then
    validates the warmed paths exist and are non-empty before the
    `warmed` stage COPY-s them. Stdin redirected from /dev/zero so
    the Cargo Maven plugin behind atlas-run does not see EOF and
    shut Jira down mid-warm during the no-TTY docker build.

  scripts/smoke.sh
    Local + CI smoke harness: starts the image, polls Dashboard.jspa
    until ready, asserts /serverInfo returns the expected version,
    dumps container logs to ./artifacts/ regardless of outcome.

  .github/workflows/ghcr-publish.yml
    workflow_dispatch publish job. Exposes every Dockerfile ARG as an
    input. Always builds and pushes both the unwarmed and warmed
    variants in a single run; the optional `tag_latest` boolean also
    pushes `:<major>-latest` and `:<major>-warm-latest` floating tags.
    Pushes to GHCR under the repository owner's namespace.

  README.md
    Adds "Targeting a different Jira version" and "Known-good build-arg
    combinations" subsections under Usage; the latter holds the
    validated Jira 8/9/10/11 matrix and AMPS line gotchas. Existing
    About / Usage / Travis CI / Contributors sections are unchanged.

The existing dockerpublish.yml workflow is left untouched; it continues to build and push to Docker Hub on master pushes using its existing secrets, now producing a Jira 8.20.30 image (the new ARG default) instead of the previous 8.9.0.