### PR TITLE
Fix to the `maven-plugin`

### DIFF
--- a/plugin/pom.xml.template
+++ b/plugin/pom.xml.template
@@ -51,18 +51,23 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- atlassian-spring-scanner is a Jira platform artefact and
+             is on jira-maven-plugin's banned-dependencies list when
+             bundled (compile/runtime scope). Mark both as `provided`
+             so the annotation processor and runtime are available at
+             build time but not packaged into the plugin jar. -->
         <dependency>
             <groupId>com.atlassian.plugin</groupId>
             <artifactId>atlassian-spring-scanner-annotation</artifactId>
             <version>${atlassian.spring.scanner.version}</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>com.atlassian.plugin</groupId>
             <artifactId>atlassian-spring-scanner-runtime</artifactId>
             <version>${atlassian.spring.scanner.version}</version>
-            <scope>runtime</scope>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -85,10 +90,15 @@
             <version>1.1.1</version>
             <scope>provided</scope>
         </dependency>
+        <!-- gson is supplied by the Jira runtime (atlassian-bundled-libs);
+             omit a scope here and the default `compile` triggers the
+             banned-dependencies enforcer. `provided` keeps it on the
+             compile classpath without packaging it into the plugin jar. -->
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.8.9</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Uncomment to use TestKit in your project. Details at https://bitbucket.org/atlassian/jira-testkit -->


### PR DESCRIPTION
`jira-maven-plugin` 8.2.3 (and later) enforces a banned-dependencies rule that fails the build when a Jira platform artefact is bundled into the plugin jar. The atlas-create-jira-plugin scaffold ships `atlassian-spring-scanner-annotation` as `compile` and `-runtime` as `runtime`, both of which package the artifact:

    [WARNING] Rule 0: BannedDependencies failed
    Found Banned Dependency:
      com.atlassian.plugin:atlassian-spring-scanner-annotation:jar:2.1.17

Switch both scopes to `provided`. The annotation processor stays available at compile time and Jira itself supplies the runtime, so nothing functional changes - only the jar layout.